### PR TITLE
feat: fix image list design

### DIFF
--- a/pages/images/index.vue
+++ b/pages/images/index.vue
@@ -7,14 +7,20 @@
       </h2>
     </div>
     <div>
-      <b-row class="text-right">
-        <b-col v-for="image in images" :key="image.id">
+      <b-row class="text-center">
+        <b-col v-for="image in images" :key="image.id" class="image-grid">
           <b-badge
             :variant="categoryVariant(image.category.id)"
-            class="shadow"
+            class="shadow image-label"
             >{{ image.category.name }}</b-badge
           >
-          <b-img rounded center fluid :src="image.url" class="shadow" />
+          <b-img
+            rounded
+            center
+            fluid
+            :src="image.url"
+            class="image-view shadow"
+          />
         </b-col>
       </b-row>
     </div>
@@ -31,9 +37,9 @@ export default Vue.extend({
         {
           url: '',
           category: {
-            id: null
-          }
-        }
+            id: null,
+          },
+        },
       ],
     }
   },
@@ -62,3 +68,19 @@ export default Vue.extend({
   },
 })
 </script>
+
+<style lang="scss" scoped>
+.image-grid {
+  max-width: 10.5em;
+  margin-bottom: 3em;
+
+  .image-label {
+    width: 10.5em;
+  }
+
+  .image-view {
+    display: inline-block;
+    max-height: 5em;
+  }
+}
+</style>


### PR DESCRIPTION
## before
![2021-12-27 23 14 49 lgtm mojamoja cloud 1ae07f41ba5a](https://user-images.githubusercontent.com/38337195/147482199-e5567cda-215e-47db-9635-c0beef096cee.png)

## after
![2021-12-27 23 37 58 lgtm mojamoja cloud 6bce403aee96](https://user-images.githubusercontent.com/38337195/147482206-f39e3002-aecf-4706-95d7-bb24fcc4d404.png)


## Summary
- labelの幅を固定
- 画像の縦幅制限
